### PR TITLE
Update regex to detect IQSDK src file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@
 # ----------------------------------------------------------------------------------------------
 
 build: 
-	vsce package
+	npx vsce package
 
 install:
 	code --install-extension intel-quantum-sdk-1.4.1.vsix

--- a/package.json
+++ b/package.json
@@ -120,6 +120,7 @@
     "@types/vscode": "^1.56.0",
     "@typescript-eslint/eslint-plugin": "^4.14.1",
     "@typescript-eslint/parser": "^4.14.1",
+    "@vscode/vsce": "^2.21.0",
     "eslint": "^7.19.0",
     "glob": "^7.1.6",
     "mocha": "^10.2.0",

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -197,7 +197,7 @@ export function activate(context: vscode.ExtensionContext) {
 				return
 			}
 		} else if (editor.document.languageId === "cpp") {
-			const regex = new RegExp(/[^\S\r\n]*#[^\S\r\n]*include[^\S\r\n]*<[^\S\r\n]*quantum.hpp[^\S\r\n]*>[^\S\r\n]*/)
+			const regex = new RegExp(/[ \t]*#[ \t]*include[ \t]*<clang\/Quantum\/quintrinsics.h>[ \t]*/)
 			if (regex.test(editorText)) {
 				vscode.commands.executeCommand('setContext', 'customContext.quantumCPPScript', true)
 				return


### PR DESCRIPTION
Old regex targeted IQS backend, use quintrinsics to taret all backends.

Update node module for VS extension creation to non-deprecated package.

Call node executable explicitly via nox in Makefile for pristine environments.
